### PR TITLE
docs: create comprehensive README for oss-kit

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,77 @@
+# oss-kit
+
+[English](README.md) | 한국어
+
+**oss-kit**은 새로운 오픈소스 프로젝트를 빠르게 시작할 수 있도록 돕는 [GitHub 템플릿 저장소](https://docs.github.com/ko/repositories/creating-and-managing-repositories/creating-a-template-repository)입니다.
+
+이 템플릿은 **프로젝트 초기에 필요한 boilerplate 설정을 줄여주고**, 잘 구조화된 오픈소스 저장소를 빠르게 설정할 수 있는 필수 구성을 제공합니다.
+
+단순하게 설계되어 있어 쉽게 시작할 수 있으며, 최신 GitHub 기능과 modern tooling을 반영하여 지속적으로 업데이트됩니다.
+
+---
+
+## 프로젝트 상태
+
+⚠️ 이 템플릿은 현재 개발 중이며, **외부 기여는 아직 받지 않습니다**.
+프로젝트가 안정적인 단계에 도달하면 공식 기여 가이드라인에 따라 기여를 환영할 예정입니다.
+
+---
+
+## 목차
+
+- [Problem Statement](#problem-statement)
+- [Features](#features)
+- [Repository Contents](#repository-contents)
+- [Contributing](#contributing)
+- [License](#license)
+
+---
+
+## Problem Statement
+
+새로운 오픈소스 프로젝트를 시작할 때, 코드를 작성하기 전에 여러 설정 작업이 필요합니다.
+예를 들어: Issue Template, Pull Request Template, Code of Conduct, Contribution Guide, Branch Rule, Commit Convention 등을 모두 수동으로 구성해야 합니다.
+
+이 과정은 반복적이고, 시간이 많이 소요되며, 프로젝트마다 일관성이 떨어지는 경우가 많습니다.
+**oss-kit**은 오픈소스 저장소를 시작하는 누구나 일관되고 현대적인 프로젝트 초기화를 보장하는 즉시 사용 가능한 템플릿을 제공하여 이 문제를 해결합니다.
+
+---
+
+## Features
+
+- **가벼운 시작**: 빠르게 시작할 수 있는 최소한의 설정
+- **Modern tooling**: 최신 GitHub 기능과 도구로 지속적으로 업데이트
+- **필수 자산 포함**: Issue Template, PR Template, Code of Conduct, Contribution Guide, Branch Rule 제공
+- **GitHub Projects 통합**: GitHub Projects 워크플로우와 함께 작동하도록 설계
+- **Custom Commit Convention**: 이 템플릿에 맞춤화된 Conventional Commits의 수정 버전 사용
+
+---
+
+## Repository Contents
+
+이 템플릿은 오픈소스 프로젝트 운영에 필요한 필수 문서와 구성을 포함합니다.
+
+- **README.md**: 프로젝트 소개 및 사용 정보
+- **CONTRIBUTION.md**: Contribution Guide
+- **CODE_OF_CONDUCT.md**: Code of Conduct
+- **LICENSE**: 라이선스 정보
+- **agents.md**: 프로젝트 역할과 책임 정의
+- **docs/**
+  - **project-board.md**: GitHub Projects 워크플로우 가이드
+- **.github/**
+  - **ISSUE_TEMPLATE/**: GitHub Issue 템플릿
+  - **PULL_REQUEST_TEMPLATE.md**: Pull Request 템플릿
+
+---
+
+## Contributing
+
+현재는 외부 기여를 받지 않습니다.
+기여가 오픈되면 [CONTRIBUTION.md](CONTRIBUTION.md)를 참고해 주세요.
+
+---
+
+## License
+
+이 프로젝트는 [MIT License](LICENSE) 하에 라이선스가 부여됩니다.
+자세한 내용은 LICENSE 파일을 참고하세요.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # oss-kit
 
+English | [한국어](README.ko.md)
+
 **oss-kit** is a [GitHub Template Repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository) designed to help you kickstart new open-source projects.  
 
 This template reduces the **boilerplate setup required at the beginning of a project** and provides essential configurations to quickly set up a well-structured open-source repository.  


### PR DESCRIPTION
## Requirement

Resolves #1

Create a clear and comprehensive README that explains oss-kit's purpose as a lightweight GitHub template repository for kickstarting open-source projects.

## Implementation

- Rewrote README with clear project description and problem statement
- Removed Turborepo-specific references to emphasize template flexibility  
- Added structured sections: Project Status, Problem Statement, Features, Repository Contents, Contributing, and License
- Clarified that the template reduces boilerplate setup required at the beginning of a project
- Emphasized lightweight nature and continuous updates with latest GitHub features
- Updated contribution guidelines to reflect current development status
- Streamlined content to focus on template's core value proposition

## Test

N/A - Documentation only change

## Human Check 
~~🤖 Generated with [Claude Code](https://claude.ai/code)~~
- [x] I reviewed it